### PR TITLE
Add Emacs dir locals

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((rust-mode . ((indent-tabs-mode . t)
+               (tab-width . 3)
+               (rust-indent-offset . 3))))


### PR DESCRIPTION
Set `.dir-locals.el` so Emacs doesn't break all indentation automatically.